### PR TITLE
fix: correct pgrep escaping to prevent undefined variable warnings

### DIFF
--- a/src/bowerbird-test/bowerbird-suite.mk
+++ b/src/bowerbird-test/bowerbird-suite.mk
@@ -295,7 +295,7 @@ define bowerbird::test::__suite-generate-rules # output-file, suite-name
 		'			printf "\e[1;31mFailed: $$*\e[0m\n" > $$(BOWERBIRD_TEST/SUITE/$2/workdir-results)/$$*.$$(BOWERBIRD_TEST/SUITE/$2/ext-fail) && \' \
 		'				echo && cat $$(BOWERBIRD_TEST/SUITE/$2/workdir-logs)/$$*.$$(BOWERBIRD_TEST/SUITE/$2/ext-log) >&2 && \' \
 		'				echo && printf "\e[1;31mFailed: $$*\e[0m\n" >&2 && \' \
-		'					(test $$(BOWERBIRD_TEST/SUITE/$2/fail-fast) -eq 0 || (kill -TERM $$$$$$(pgrep -f $$(BOWERBIRD_TEST/SUITE/$2/process-tag)))) && \' \
+		'					(test $$(BOWERBIRD_TEST/SUITE/$2/fail-fast) -eq 0 || (kill -TERM $$$$(pgrep -f $$(BOWERBIRD_TEST/SUITE/$2/process-tag)))) && \' \
 		'					exit $$(BOWERBIRD_TEST/SUITE/$2/fail-exit-code) \' \
 		'		)' \
 		>> $1


### PR DESCRIPTION
Changed from 6 dollar signs to 4 in the printf statement that generates the test runner pattern rule. This produces $$(pgrep ...) in the generated file instead of $$$(pgrep ...), which was causing Make to try to expand $(pgrep ...) as a Make variable due to --warn-undefined-variables.

The correct escaping:
- Source (bowerbird-suite.mk): $$$$(pgrep ...)  [4 dollar signs]
- Generated file: $$(pgrep ...)                [2 dollar signs]
- Shell execution: $(pgrep ...)                 [shell command substitution]

This fixes the repeated 'warning: undefined variable' messages when running the test suite.