### PR TITLE
fix: prevent Make jobserver deadlock in mock tests

### DIFF
--- a/make/private.mk
+++ b/make/private.mk
@@ -1,6 +1,6 @@
 # Config
 .SUFFIXES:
-MAKEFLAGS += --jobs
+MAKEFLAGS += --jobs=8
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-builtin-variables
 MAKEFLAGS += --warn-undefined-variables

--- a/src/bowerbird-test/bowerbird-mock.mk
+++ b/src/bowerbird-test/bowerbird-mock.mk
@@ -59,6 +59,6 @@ $1: SHELL = /bin/sh
 $1:
 	@mkdir -p $$(dir $$(WORKDIR_TEST)/$1/.results)
 	@: > $$(WORKDIR_TEST)/$1/.results
-	$$(MAKE) BOWERBIRD_MOCK_RESULTS=$$(WORKDIR_TEST)/$1/.results $4 $2
+	$$(MAKE) -j1 BOWERBIRD_MOCK_RESULTS=$$(WORKDIR_TEST)/$1/.results $4 $2
 	$$(call bowerbird::test::compare-file-content-from-var,$$(WORKDIR_TEST)/$1/.results,$3)
 endef


### PR DESCRIPTION
Add -j1 flag to recursive Make calls in mock tests to prevent deadlock when running with unlimited parallelism (--jobs).

Problem:
- With MAKEFLAGS += --jobs (unlimited), the test suite spawns ~230 tests in parallel
- Each mock test spawns a recursive Make process
- Recursive Make processes inherit --jobs and compete for jobserver tokens
- This causes deadlock and hangs on random mock tests each run

Solution:
- Force recursive Make calls in mock tests to run with -j1 (serial)
- Mock tests don't need parallelism - they only capture commands from a single target
- Parent Make can still run all tests in parallel

This fixes hanging on tests like:
- test-mock-shellflags-many-flags
- test-mock-multiline-complex
- test-mock-multiline-basic
- test-mock-error-comparison-fails
- test-mock-multiple-commands